### PR TITLE
add replayapi cli to runtime container

### DIFF
--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -18,6 +18,8 @@ RUN \
     apt-get update && \
     /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
     /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run git -C /openhands clone https://github.com/replayio-public/replayapi.git && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run /openhands/replayapi/scripts/install-deps.sh && \
     # Set environment variables
     echo "OH_INTERPRETER_PATH=$(/openhands/micromamba/bin/micromamba run -n openhands poetry run python -c "import sys; print(sys.executable)")" >> /etc/environment && \
     # Clear caches


### PR DESCRIPTION
to verify this works:

1. create the `Dockerfile`:
```bash
OpenHands % poetry run python3 openhands/runtime/utils/runtime_build.py \
    --base_image nikolaik/python-nodejs:python3.12-nodejs22 \
    --build_folder containers/runtime
```

2. Build the image:
```bash
OpenHands % cd containers/runtime
runtime % docker build .

... lots of docker output here ...
```

3. Run the cli:
```bash
runtime % docker run -it <image id from step 2> /openhands/replayapi/scripts/run.sh --help
Usage: main [options] [command]

Options:
  -h, --help                Display help for command

Commands:
  fetch-comments [options]  Fetch comments from a recording
  help [command]            Display help for command
  session                   Manage persistent sessions with replay api
  version
```