### PR TITLE
mount REPLAY_DIR into the runtime container.  wire up the replay cli

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -231,6 +231,12 @@ llm_config = 'gpt3'
 # BrowserGym environment to use for evaluation
 #browsergym_eval_env = ""
 
+#################################### Replay ###################################
+# Configuration for replay integration
+##############################################################################
+[replay]
+#api_key = ''
+
 #################################### Security ###################################
 # Configuration for security features
 ##############################################################################

--- a/config.template.toml
+++ b/config.template.toml
@@ -235,7 +235,11 @@ llm_config = 'gpt3'
 # Configuration for replay integration
 ##############################################################################
 [replay]
+# a replay api key for either the workspace or user (config item name means our REPLAY_API_KEY env var will work)
 #api_key = ''
+
+# the parent directory of both devtools and replayapi git repos (config item name means our REPLAY_DIR env var will work)
+#dir = ''
 
 #################################### Security ###################################
 # Configuration for security features

--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -13,7 +13,10 @@ export function handleObservationMessage(message: ObservationMessage) {
       if (message.extras.hidden) break;
       store.dispatch(appendOutput(message.content));
       break;
-    case ObservationType.RUN_IPYTHON:
+    case ObservationType.RUN_REPLAY:
+        store.dispatch(appendOutput(message.content));
+        break;
+      case ObservationType.RUN_IPYTHON:
       // FIXME: render this as markdown
       store.dispatch(appendJupyterOutput(message.content));
       break;

--- a/frontend/src/services/observations.ts
+++ b/frontend/src/services/observations.ts
@@ -14,9 +14,9 @@ export function handleObservationMessage(message: ObservationMessage) {
       store.dispatch(appendOutput(message.content));
       break;
     case ObservationType.RUN_REPLAY:
-        store.dispatch(appendOutput(message.content));
-        break;
-      case ObservationType.RUN_IPYTHON:
+      store.dispatch(appendOutput(message.content));
+      break;
+    case ObservationType.RUN_IPYTHON:
       // FIXME: render this as markdown
       store.dispatch(appendJupyterOutput(message.content));
       break;

--- a/frontend/src/types/ActionType.tsx
+++ b/frontend/src/types/ActionType.tsx
@@ -17,6 +17,9 @@ enum ActionType {
   // Runs a IPython command.
   RUN_IPYTHON = "run_ipython",
 
+  // Runs a Replay command.
+  RUN_REPLAY = "run_replay",
+
   // Opens a web page.
   BROWSE = "browse",
 

--- a/frontend/src/types/ObservationType.tsx
+++ b/frontend/src/types/ObservationType.tsx
@@ -11,6 +11,9 @@ enum ObservationType {
   // The output of an IPython command
   RUN_IPYTHON = "run_ipython",
 
+  // The output of a replay command
+  RUN_REPLAY = "run_replay",
+
   // A message from the user
   CHAT = "chat",
 

--- a/frontend/src/types/core/actions.ts
+++ b/frontend/src/types/core/actions.ts
@@ -38,6 +38,16 @@ export interface IPythonAction extends OpenHandsActionEvent<"run_ipython"> {
   };
 }
 
+export interface ReplayAction extends OpenHandsActionEvent<"run_replay"> {
+  source: "agent";
+  args: {
+    command: string;
+    confirmation_state: "confirmed" | "rejected" | "awaiting_confirmation";
+    thought: string;
+    hidden?: boolean;
+  };
+}
+
 export interface FinishAction extends OpenHandsActionEvent<"finish"> {
   source: "agent";
   args: {

--- a/frontend/src/types/core/base.ts
+++ b/frontend/src/types/core/base.ts
@@ -3,6 +3,7 @@ type OpenHandsEventType =
   | "agent_state_changed"
   | "run"
   | "run_ipython"
+  | "run_replay"
   | "delegate"
   | "browse"
   | "browse_interactive"

--- a/frontend/src/types/core/observations.ts
+++ b/frontend/src/types/core/observations.ts
@@ -27,6 +27,15 @@ export interface IPythonObservation
   };
 }
 
+export interface ReplayObservation
+  extends OpenHandsObservationEvent<"run_replay"> {
+  source: "agent";
+  extras: {
+    command: string;
+    exit_code: number;
+  };
+}
+
 export interface DelegateObservation
   extends OpenHandsObservationEvent<"delegate"> {
   source: "agent";

--- a/openhands/agenthub/codeact_agent/function_calling.py
+++ b/openhands/agenthub/codeact_agent/function_calling.py
@@ -20,6 +20,7 @@ from openhands.events.action import (
     FileEditAction,
     IPythonRunCellAction,
     MessageAction,
+    ReplayCmdRunAction,
 )
 from openhands.events.tool import ToolCallMetadata
 
@@ -28,6 +29,38 @@ SYSTEM_PROMPT = """You are a helpful assistant that can interact with a computer
 * If user provides a path, you should NOT assume it's relative to the current working directory. Instead, you should explore the file system to find the file before working on it.
 </IMPORTANT>
 """
+
+_REPLAY_DESCRIPTION = """
+Runs a command against a recording of execution.  There are several available:
+
+* `session start` - Starts a new session with a given recording.  Requires the recording id.  Outputs the session id.
+* `session stop` - Stops the current session.  Requires the session id.
+* `fetch-comments` - Fetches all comments associated with a recording.
+
+All responses from the replay tool are in JSON format.
+"""
+
+ReplayRunCmdTool = ChatCompletionToolParam(
+    type='function',
+    function=ChatCompletionToolParamFunctionChunk(
+        name='execute_replay',
+        description=_REPLAY_DESCRIPTION,
+        parameters={
+            'type': 'object',
+            'properties': {
+                'command': {
+                    'type': 'string',
+                    'description': 'The command to replay.',
+                },
+                'recording_id': {
+                    'type': 'string',
+                    'description': 'The recording ID to replay against.',
+                }
+            },
+            'required': ['command'],
+        },
+    ),
+)
 
 _BASH_DESCRIPTION = """Execute a bash command in the terminal.
 * Long running commands: For commands that may run indefinitely, it should be run in the background and the output should be redirected to a file, e.g. command = `python3 app.py > server.log 2>&1 &`.
@@ -338,6 +371,8 @@ def response_to_actions(response: ModelResponse) -> list[Action]:
                 ) from e
             if tool_call.function.name == 'execute_bash':
                 action = CmdRunAction(**arguments)
+            elif tool_call.function.name == 'execute_replay':
+                action = ReplayCmdRunAction(**arguments)
             elif tool_call.function.name == 'execute_ipython_cell':
                 action = IPythonRunCellAction(**arguments)
             elif tool_call.function.name == 'delegate_to_browsing_agent':
@@ -384,6 +419,7 @@ def get_tools(
     codeact_enable_browsing_delegate: bool = False,
     codeact_enable_llm_editor: bool = False,
     codeact_enable_jupyter: bool = False,
+    codeact_enable_replay: bool = False,
 ) -> list[ChatCompletionToolParam]:
     tools = [CmdRunTool, FinishTool]
     if codeact_enable_browsing_delegate:
@@ -394,4 +430,6 @@ def get_tools(
         tools.append(LLMBasedFileEditTool)
     else:
         tools.append(StrReplaceEditorTool)
+    if codeact_enable_replay:
+        tools.append(ReplayRunCmdTool)
     return tools

--- a/openhands/core/config/agent_config.py
+++ b/openhands/core/config/agent_config.py
@@ -12,6 +12,7 @@ class AgentConfig:
         codeact_enable_browsing_delegate: Whether browsing delegate is enabled in the action space. Default is False. Only works with function calling.
         codeact_enable_llm_editor: Whether LLM editor is enabled in the action space. Default is False. Only works with function calling.
         codeact_enable_jupyter: Whether Jupyter is enabled in the action space. Default is False.
+        codeact_enable_replay: Whether Replay is enabled in the action space. Default is False.
         micro_agent_name: The name of the micro agent to use for this agent.
         memory_enabled: Whether long-term memory (embeddings) is enabled.
         memory_max_threads: The maximum number of threads indexing at the same time for embeddings.
@@ -22,6 +23,7 @@ class AgentConfig:
     codeact_enable_browsing_delegate: bool = True
     codeact_enable_llm_editor: bool = False
     codeact_enable_jupyter: bool = True
+    codeact_enable_replay: bool = True
     micro_agent_name: str | None = None
     memory_enabled: bool = False
     memory_max_threads: int = 3

--- a/openhands/core/config/app_config.py
+++ b/openhands/core/config/app_config.py
@@ -10,6 +10,7 @@ from openhands.core.config.config_utils import (
     get_field_info,
 )
 from openhands.core.config.llm_config import LLMConfig
+from openhands.core.config.replay_config import ReplayConfig
 from openhands.core.config.sandbox_config import SandboxConfig
 from openhands.core.config.security_config import SecurityConfig
 
@@ -21,6 +22,7 @@ class AppConfig:
     Attributes:
         llms: A dictionary of name -> LLM configuration. Default config is under 'llm' key.
         agents: A dictionary of name -> Agent configuration. Default config is under 'agent' key.
+        replay: The replay configuration.
         default_agent: The name of the default agent to use.
         sandbox: The sandbox configuration.
         runtime: The runtime environment.
@@ -47,6 +49,7 @@ class AppConfig:
     llms: dict[str, LLMConfig] = field(default_factory=dict)
     agents: dict = field(default_factory=dict)
     default_agent: str = OH_DEFAULT_AGENT
+    replay: ReplayConfig = field(default_factory=ReplayConfig)
     sandbox: SandboxConfig = field(default_factory=SandboxConfig)
     security: SecurityConfig = field(default_factory=SecurityConfig)
     runtime: str = 'eventstream'

--- a/openhands/core/config/replay_config.py
+++ b/openhands/core/config/replay_config.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass, fields
+
+from openhands.core.config.config_utils import get_field_info
+
+REPLAY_SENSITIVE_FIELDS = ['api_key']
+
+@dataclass
+class ReplayConfig:
+    """Configuration for the replay api.
+
+    Attributes:
+        api_key: The API key to use for the replay API.
+    """
+
+    api_key: str | None = None
+
+    def defaults_to_dict(self) -> dict:
+        """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""
+        result = {}
+        for f in fields(self):
+            result[f.name] = get_field_info(f)
+        return result
+    
+    def to_safe_dict(self):
+        """Return a dict with the sensitive fields replaced with ******."""
+        ret = self.__dict__.copy()
+        for k, v in ret.items():
+            if k in REPLAY_SENSITIVE_FIELDS:
+                ret[k] = '******' if v else None
+            elif isinstance(v, ReplayConfig):
+                ret[k] = v.to_safe_dict()
+        return ret
+    
+    def __str__(self):
+        attr_str = []
+        for f in fields(self):
+            attr_name = f.name
+            attr_value = getattr(self, f.name)
+
+            attr_str.append(f'{attr_name}={repr(attr_value)}')
+
+        return f"ReplayConfig({', '.join(attr_str)})"

--- a/openhands/core/config/replay_config.py
+++ b/openhands/core/config/replay_config.py
@@ -10,9 +10,11 @@ class ReplayConfig:
 
     Attributes:
         api_key: The API key to use for the replay API.
+        dir: The parent directory of both devtools and replayapi git repositories.
     """
 
     api_key: str | None = None
+    dir: str | None = None
 
     def defaults_to_dict(self) -> dict:
         """Serialize fields to a dict for the frontend, including type hints, defaults, and whether it's optional."""
@@ -20,7 +22,7 @@ class ReplayConfig:
         for f in fields(self):
             result[f.name] = get_field_info(f)
         return result
-    
+
     def to_safe_dict(self):
         """Return a dict with the sensitive fields replaced with ******."""
         ret = self.__dict__.copy()
@@ -30,7 +32,7 @@ class ReplayConfig:
             elif isinstance(v, ReplayConfig):
                 ret[k] = v.to_safe_dict()
         return ret
-    
+
     def __str__(self):
         attr_str = []
         for f in fields(self):

--- a/openhands/core/config/utils.py
+++ b/openhands/core/config/utils.py
@@ -17,6 +17,7 @@ from openhands.core.config.config_utils import (
     OH_MAX_ITERATIONS,
 )
 from openhands.core.config.llm_config import LLMConfig
+from openhands.core.config.replay_config import ReplayConfig
 from openhands.core.config.sandbox_config import SandboxConfig
 
 load_dotenv()
@@ -144,6 +145,12 @@ def load_from_toml(cfg: AppConfig, toml_file: str = 'config.toml'):
                             )
                             llm_config = LLMConfig.from_dict(nested_value)
                             cfg.set_llm_config(llm_config, nested_key)
+                elif key is not None and key.lower() == 'replay':
+                    logger.openhands_logger.debug(
+                        'Attempt to load replay config from config toml'
+                    )
+                    replay_config = ReplayConfig(**value)
+                    cfg.replay = replay_config
                 elif not key.startswith('sandbox') and key.lower() != 'core':
                     logger.openhands_logger.warning(
                         f'Unknown key in {toml_file}: "{key}"'

--- a/openhands/core/schema/action.py
+++ b/openhands/core/schema/action.py
@@ -36,6 +36,10 @@ class ActionTypeSchema(BaseModel):
     """Runs a IPython cell.
     """
 
+    RUN_REPLAY: str = Field(default='run_replay')
+    """Runs a Replay command.
+    """
+
     BROWSE: str = Field(default='browse')
     """Opens a web page.
     """

--- a/openhands/core/schema/observation.py
+++ b/openhands/core/schema/observation.py
@@ -24,6 +24,10 @@ class ObservationTypeSchema(BaseModel):
     """Runs a IPython cell.
     """
 
+    RUN_REPLAY: str = Field(default='run_replay')
+    """Runs a Replay command.
+    """
+
     CHAT: str = Field(default='chat')
     """A message from the user
     """

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -8,7 +8,6 @@ from openhands.events.action.agent import (
 )
 from openhands.events.action.browse import BrowseInteractiveAction, BrowseURLAction
 from openhands.events.action.commands import CmdRunAction, IPythonRunCellAction
-from openhands.events.action.replay import ReplayCmdRunAction
 from openhands.events.action.empty import NullAction
 from openhands.events.action.files import (
     FileEditAction,
@@ -16,6 +15,7 @@ from openhands.events.action.files import (
     FileWriteAction,
 )
 from openhands.events.action.message import MessageAction
+from openhands.events.action.replay import ReplayCmdRunAction
 from openhands.events.action.tasks import AddTaskAction, ModifyTaskAction
 
 __all__ = [
@@ -37,5 +37,5 @@ __all__ = [
     'IPythonRunCellAction',
     'MessageAction',
     'ActionConfirmationStatus',
-    'ReplayRunCmdAction',
+    'ReplayCmdRunAction',
 ]

--- a/openhands/events/action/__init__.py
+++ b/openhands/events/action/__init__.py
@@ -8,6 +8,7 @@ from openhands.events.action.agent import (
 )
 from openhands.events.action.browse import BrowseInteractiveAction, BrowseURLAction
 from openhands.events.action.commands import CmdRunAction, IPythonRunCellAction
+from openhands.events.action.replay import ReplayCmdRunAction
 from openhands.events.action.empty import NullAction
 from openhands.events.action.files import (
     FileEditAction,
@@ -36,4 +37,5 @@ __all__ = [
     'IPythonRunCellAction',
     'MessageAction',
     'ActionConfirmationStatus',
+    'ReplayRunCmdAction',
 ]

--- a/openhands/events/action/replay.py
+++ b/openhands/events/action/replay.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from openhands.core.schema import ActionType
+from openhands.events.action.action import (
+    Action,
+    ActionConfirmationStatus,
+    ActionSecurityRisk,
+)
+
+
+@dataclass
+class ReplayCmdRunAction(Action):
+    command: str
+    thought: str = ''
+    blocking: bool = True
+    keep_prompt: bool = False
+    hidden: bool = False
+    action: str = ActionType.RUN_REPLAY
+    runnable: ClassVar[bool] = True
+    confirmation_state: ActionConfirmationStatus = ActionConfirmationStatus.CONFIRMED
+    security_risk: ActionSecurityRisk | None = None
+    recording_id: str = ''
+    session_id: str = ''
+
+    @property
+    def message(self) -> str:
+        return f'Running replay command: {self.command}'
+
+    def __str__(self) -> str:
+        ret = f'**ReplayCmdRunAction (source={self.source})**\n'
+        if self.thought:
+            ret += f'THOUGHT: {self.thought}\n'
+        ret += f'COMMAND:\n{self.command}'
+        return ret

--- a/openhands/events/observation/__init__.py
+++ b/openhands/events/observation/__init__.py
@@ -4,6 +4,9 @@ from openhands.events.observation.commands import (
     CmdOutputObservation,
     IPythonRunCellObservation,
 )
+from openhands.events.observation.replay import (
+    ReplayCmdOutputObservation,
+)
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
 from openhands.events.observation.error import ErrorObservation, FatalErrorObservation
@@ -20,6 +23,7 @@ __all__ = [
     'Observation',
     'NullObservation',
     'CmdOutputObservation',
+    'ReplayCmdOutputObservation',
     'IPythonRunCellObservation',
     'BrowserOutputObservation',
     'FileReadObservation',

--- a/openhands/events/observation/replay.py
+++ b/openhands/events/observation/replay.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+
+from openhands.core.schema import ObservationType
+from openhands.events.observation.observation import Observation
+
+
+@dataclass
+class ReplayCmdOutputObservation(Observation):
+    """This data class represents the output of a replay command."""
+
+    command_id: int
+    command: str
+    exit_code: int = 0
+    hidden: bool = False
+    observation: str = ObservationType.RUN_REPLAY
+    interpreter_details: str = ''
+
+    @property
+    def error(self) -> bool:
+        return self.exit_code != 0
+
+    @property
+    def message(self) -> str:
+        return f'Command `{self.command}` executed with exit code {self.exit_code}.'
+
+    def __str__(self) -> str:
+        return f'**ReplayCmdOutputObservation (source={self.source}, exit code={self.exit_code})**\n{self.content}'

--- a/openhands/events/serialization/action.py
+++ b/openhands/events/serialization/action.py
@@ -11,6 +11,9 @@ from openhands.events.action.commands import (
     CmdRunAction,
     IPythonRunCellAction,
 )
+from openhands.events.action.replay import (
+    ReplayCmdRunAction,
+)
 from openhands.events.action.empty import NullAction
 from openhands.events.action.files import (
     FileEditAction,
@@ -23,6 +26,7 @@ from openhands.events.action.tasks import AddTaskAction, ModifyTaskAction
 actions = (
     NullAction,
     CmdRunAction,
+    ReplayCmdRunAction,
     IPythonRunCellAction,
     BrowseURLAction,
     BrowseInteractiveAction,

--- a/openhands/events/serialization/observation.py
+++ b/openhands/events/serialization/observation.py
@@ -4,6 +4,7 @@ from openhands.events.observation.commands import (
     CmdOutputObservation,
     IPythonRunCellObservation,
 )
+from openhands.events.observation.replay import ReplayCmdOutputObservation
 from openhands.events.observation.delegate import AgentDelegateObservation
 from openhands.events.observation.empty import NullObservation
 from openhands.events.observation.error import ErrorObservation
@@ -19,6 +20,7 @@ from openhands.events.observation.success import SuccessObservation
 observations = (
     NullObservation,
     CmdOutputObservation,
+    ReplayCmdOutputObservation,
     IPythonRunCellObservation,
     BrowserOutputObservation,
     FileReadObservation,

--- a/openhands/runtime/README.md
+++ b/openhands/runtime/README.md
@@ -47,6 +47,7 @@ Key features of the `ActionExecutor` class:
 3. **Action Execution**:
    - Different types of actions are executed:
      - Bash commands using `run` method
+     - Replay commands using `run_replay` method
      - IPython cells using `run_ipython` method
      - File operations (read/write) using `read` and `write` methods
      - Web browsing using `browse` and `browse_interactive` methods

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -174,8 +174,7 @@ class ActionExecutor:
         return self.bash_session.run(action)
 
     async def run_replay(self, action: ReplayCmdRunAction) -> ReplayCmdOutputObservation:
-        # TODO: get the replay API key from wherever it's stored
-        command = f'/openhands/replayapi/scripts/run.sh {action.command} -k XXXX'
+        command = f'/openhands/replayapi/scripts/run.sh {action.command}'
         if action.recording_id != '':
             command = command + f' -r {action.recording_id}'
         if action.session_id != '':

--- a/openhands/runtime/action_execution_server.py
+++ b/openhands/runtime/action_execution_server.py
@@ -174,7 +174,7 @@ class ActionExecutor:
         return self.bash_session.run(action)
 
     async def run_replay(self, action: ReplayCmdRunAction) -> ReplayCmdOutputObservation:
-        command = f'/openhands/replayapi/scripts/run.sh {action.command}'
+        command = f'/replay/replayapi/scripts/run.sh {action.command}'
         if action.recording_id != '':
             command = command + f' -r {action.recording_id}'
         if action.session_id != '':

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -90,6 +90,8 @@ class Runtime(FileEditRuntimeMixin):
         self.add_env_vars(self.initial_env_vars)
         if self.config.sandbox.runtime_startup_env_vars:
             self.add_env_vars(self.config.sandbox.runtime_startup_env_vars)
+        if self.config.replay.api_key:
+            self.add_env_vars({'REPLAY_API_KEY': self.config.replay.api_key})
 
     def close(self) -> None:
         pass

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -93,6 +93,11 @@ class Runtime(FileEditRuntimeMixin):
         if self.config.replay.api_key:
             self.add_env_vars({'REPLAY_API_KEY': self.config.replay.api_key})
 
+        if self.config.replay.api_key:
+            self.add_env_vars({'REPLAY_API_KEY': self.config.replay.api_key})
+        if self.config.replay.dir:
+            self.add_env_vars({'REPLAY_DIR': self.config.replay.dir})
+
     def close(self) -> None:
         pass
 

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -14,10 +14,10 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
-    ReplayCmdRunAction,
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
+    ReplayCmdRunAction,
 )
 from openhands.events.event import Event
 from openhands.events.observation import (

--- a/openhands/runtime/base.py
+++ b/openhands/runtime/base.py
@@ -14,6 +14,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    ReplayCmdRunAction,
     FileReadAction,
     FileWriteAction,
     IPythonRunCellAction,
@@ -193,6 +194,10 @@ class Runtime(FileEditRuntimeMixin):
 
     @abstractmethod
     def run_ipython(self, action: IPythonRunCellAction) -> Observation:
+        pass
+
+    @abstractmethod
+    def run_replay(self, action: ReplayCmdRunAction) -> Observation:
         pass
 
     @abstractmethod

--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -18,6 +18,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    ReplayCmdRunAction,
     FileEditAction,
     FileReadAction,
     FileWriteAction,
@@ -515,6 +516,9 @@ class EventStreamRuntime(Runtime):
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:
+        return self.run_action(action)
+
+    def run_replay(self, action: ReplayCmdRunAction) -> Observation:
         return self.run_action(action)
 
     def run_ipython(self, action: IPythonRunCellAction) -> Observation:

--- a/openhands/runtime/impl/eventstream/eventstream_runtime.py
+++ b/openhands/runtime/impl/eventstream/eventstream_runtime.py
@@ -308,6 +308,20 @@ class EventStreamRuntime(Runtime):
                 f'Sandbox workspace: {self.config.workspace_mount_path_in_sandbox}'
             )
 
+            # Replay dir in sandbox
+            if self.config.replay.dir is not None:
+                if volumes is None:
+                    volumes = {}
+                volumes[self.config.replay.dir] = {
+                    'bind': "/replay",
+                    'mode': 'rw',
+                }
+            self.log(
+                'debug',
+                f'Replay volume: {self.config.replay.dir} -> /replay',
+            )
+
+
             if self.config.sandbox.browsergym_eval_env is not None:
                 browsergym_arg = (
                     f'--browsergym-eval-env {self.config.sandbox.browsergym_eval_env}'

--- a/openhands/runtime/impl/remote/remote_runtime.py
+++ b/openhands/runtime/impl/remote/remote_runtime.py
@@ -14,6 +14,7 @@ from openhands.events.action import (
     BrowseInteractiveAction,
     BrowseURLAction,
     CmdRunAction,
+    ReplayCmdRunAction,
     FileEditAction,
     FileReadAction,
     FileWriteAction,
@@ -405,6 +406,9 @@ class RemoteRuntime(Runtime):
             return obs
 
     def run(self, action: CmdRunAction) -> Observation:
+        return self.run_action(action)
+
+    def run_replay(self, action: ReplayCmdRunAction) -> Observation:
         return self.run_action(action)
 
     def run_ipython(self, action: IPythonRunCellAction) -> Observation:

--- a/openhands/runtime/utils/runtime_templates/Dockerfile.j2
+++ b/openhands/runtime/utils/runtime_templates/Dockerfile.j2
@@ -18,6 +18,8 @@ RUN \
     apt-get update && \
     /openhands/micromamba/bin/micromamba run -n openhands poetry run pip install playwright && \
     /openhands/micromamba/bin/micromamba run -n openhands poetry run playwright install --with-deps chromium && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run git -C /openhands clone https://github.com/replayio-public/replayapi.git && \
+    /openhands/micromamba/bin/micromamba run -n openhands poetry run /openhands/replayapi/scripts/install-deps.sh && \
     # Set environment variables
     echo "OH_INTERPRETER_PATH=$(/openhands/micromamba/bin/micromamba run -n openhands poetry run python -c "import sys; print(sys.executable)")" >> /etc/environment && \
     # Clear caches

--- a/openhands/server/listen.py
+++ b/openhands/server/listen.py
@@ -283,6 +283,10 @@ async def websocket_endpoint(websocket: WebSocket):
         ```json
         {"action": "run", "args": {"command": "ls -l", "thought": "", "confirmation_state": "confirmed"}}
         ```
+    - Run a replay command:
+        ```json
+        {"action": "run_replay", "args": {"command": "fetch-comments", "thought": "", "confirmation_state": "confirmed"}}
+        ```
     - Run an IPython command:
         ```json
         {"action": "run_ipython", "args": {"command": "print('Hello, IPython!')"}}


### PR DESCRIPTION
config opens for both api key and replay dir, which can be set in `config.toml`, as well as via env vars (with the config items mapping to our familiar names: `REPLAY_API_KEY`, `REPLAY_DIR`).

Mount REPLAY_DIR as /replay into the container instead of `git clone`ing them at image generation time.

leads to this interaction working
![image](https://github.com/user-attachments/assets/49bdf013-b062-499a-9fe4-198cb9fbc553)
